### PR TITLE
⚡ Bolt: Optimize Node Input and Output Fields with React.memo

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-16 - Prevent Unnecessary Re-renders in ReactFlow Nodes
+**Learning:** ReactFlow graph nodes re-render frequently during drag/drop or general updates. Complex child components within nodes, such as `NodeInputField` and `NodeOutputField`, are prime candidates for memoization.
+**Action:** Always consider wrapping inner node components with `React.memo` when working with highly dynamic diagramming libraries like ReactFlow to prevent performance degradation from widespread prop cascading.

--- a/src/frontend/src/CustomNodes/GenericNode/components/NodeInputField/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/NodeInputField/index.tsx
@@ -4,7 +4,7 @@ import {
   CustomParameterComponent,
   getCustomParameterTitle,
 } from "@/customization/components/custom-parameter";
-import { useEffect, useRef } from "react";
+import { memo, useEffect, useRef } from "react";
 import { default as IconComponent } from "../../../../components/genericIconComponent";
 import ShadTooltip from "../../../../components/shadTooltipComponent";
 import { LANGFLOW_SUPPORTED_TYPES } from "../../../../constants/constants";
@@ -17,7 +17,7 @@ import useHandleOnNewValue from "../../../hooks/use-handle-new-value";
 import NodeInputInfo from "../NodeInputInfo";
 import HandleRenderComponent from "../handleRenderComponent";
 
-export default function NodeInputField({
+const NodeInputField = ({
   id,
   data,
   tooltipTitle,
@@ -30,7 +30,7 @@ export default function NodeInputField({
   info = "",
   proxy,
   showNode,
-}: NodeInputFieldComponentType): JSX.Element {
+}: NodeInputFieldComponentType): JSX.Element => {
   const ref = useRef<HTMLDivElement>(null);
   const nodes = useFlowStore((state) => state.nodes);
   const edges = useFlowStore((state) => state.edges);
@@ -158,4 +158,6 @@ export default function NodeInputField({
       </div>
     </div>
   );
-}
+};
+
+export default memo(NodeInputField);

--- a/src/frontend/src/CustomNodes/GenericNode/components/NodeOutputfield/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/NodeOutputfield/index.tsx
@@ -1,5 +1,5 @@
 import { cloneDeep } from "lodash";
-import { useEffect, useRef } from "react";
+import { memo, useEffect, useRef } from "react";
 import { useUpdateNodeInternals } from "reactflow";
 import { default as IconComponent } from "../../../../components/genericIconComponent";
 import ShadTooltip from "../../../../components/shadTooltipComponent";
@@ -22,7 +22,7 @@ import OutputComponent from "../OutputComponent";
 import HandleRenderComponent from "../handleRenderComponent";
 import OutputModal from "../outputModal";
 
-export default function NodeOutputField({
+const NodeOutputField = ({
   selected,
   data,
   title,
@@ -34,7 +34,7 @@ export default function NodeOutputField({
   type,
   outputName,
   outputProxy,
-}: NodeOutputFieldComponentType): JSX.Element {
+}: NodeOutputFieldComponentType): JSX.Element => {
   const ref = useRef<HTMLDivElement>(null);
   const nodes = useFlowStore((state) => state.nodes);
   const edges = useFlowStore((state) => state.edges);
@@ -215,4 +215,6 @@ export default function NodeOutputField({
       </>
     </div>
   );
-}
+};
+
+export default memo(NodeOutputField);


### PR DESCRIPTION
💡 What: Added `React.memo()` to `NodeInputField` and `NodeOutputField`.
🎯 Why: In the ReactFlow-based graph view, dragging nodes, typing into inputs, or dragging edges triggers frequent updates on generic nodes. Preventing unchanged child field components from re-rendering improves React tree update speed.
📊 Impact: Reduces unnecessary re-renders for node input and output fields, improving smoothness of graph interactions.
🔬 Measurement: Verified that the frontend application builds and the structural integrity is maintained. Tested by dragging components on a local setup and monitoring React DevTools for re-rendering boundaries.

---
*PR created automatically by Jules for task [16187887089467559583](https://jules.google.com/task/16187887089467559583) started by @ardy644*