### PR TITLE
⚡ Bolt: Memoize ReactFlow custom nodes to prevent unnecessary re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-25 - ReactFlow Custom Node Memoization
+**Learning:** ReactFlow triggers re-renders on custom nodes during canvas interactions (panning, zooming) or when interacting with other nodes. Not memoizing complex custom nodes like `GenericNode` causes significant performance bottlenecks as the graph scales.
+**Action:** Always wrap `reactflow` custom node components with `React.memo()` using `export default memo(NodeComponent)` to ensure shallow prop comparison prevents unnecessary re-renders.

--- a/src/frontend/src/CustomNodes/GenericNode/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/index.tsx
@@ -1,5 +1,5 @@
 import { usePostValidateComponentCode } from "@/controllers/API/queries/nodes/use-post-validate-component-code";
-import { useEffect, useMemo, useState } from "react";
+import { memo, useEffect, useMemo, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { NodeToolbar, useUpdateNodeInternals } from "reactflow";
 import IconComponent, {
@@ -32,7 +32,7 @@ import NodeOutputField from "./components/NodeOutputfield";
 import NodeStatus from "./components/NodeStatus";
 import { NodeIcon } from "./components/nodeIcon";
 
-export default function GenericNode({
+function GenericNode({
   data,
   selected,
 }: {
@@ -421,3 +421,5 @@ export default function GenericNode({
     </>
   );
 }
+
+export default memo(GenericNode);

--- a/src/frontend/src/CustomNodes/NoteNode/index.tsx
+++ b/src/frontend/src/CustomNodes/NoteNode/index.tsx
@@ -7,7 +7,7 @@ import {
 } from "@/constants/constants";
 import { noteDataType } from "@/types/flow";
 import { cn } from "@/utils/utils";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { NodeResizer, NodeToolbar } from "reactflow";
 import IconComponent from "../../components/genericIconComponent";
 import NodeDescription from "../GenericNode/components/NodeDescription";
@@ -107,4 +107,4 @@ function NoteNode({
   );
 }
 
-export default NoteNode;
+export default memo(NoteNode);


### PR DESCRIPTION
💡 **What:** Wrapped `GenericNode` and `NoteNode` ReactFlow custom components with `React.memo()`.
🎯 **Why:** ReactFlow triggers re-renders on custom nodes during canvas interactions (panning, zooming, etc.) or when unrelated nodes update. Since `GenericNode` is a complex component containing multiple input and output fields, these unnecessary re-renders create a significant performance bottleneck, especially in large flows. Memoization ensures they only re-render when their props change.
📊 **Impact:** Significantly reduces React component re-renders during canvas interactions, improving the framerate and responsiveness of panning, zooming, and dragging actions on the canvas.
🔬 **Measurement:** Open a large flow with many generic nodes. Use the React DevTools Profiler to record interactions like panning or dragging a node. Notice that previously all nodes would re-render; with this change, only the interacted nodes or those with explicitly changed props will re-render.

---
*PR created automatically by Jules for task [13875660657817808172](https://jules.google.com/task/13875660657817808172) started by @ardy644*