### PR TITLE
⚡ Bolt: Wrap CustomNodes in React.memo()

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-25 - Prevent Unnecessary Re-renders in CustomNodes
+**Learning:** ReactFlow custom node components (like GenericNode, NoteNode) re-render heavily during canvas interactions (panning, zooming) if not properly memoized.
+**Action:** Always wrap custom node components passed to ReactFlow with `React.memo()` to optimize rendering performance, ensuring nodes only update when their props change.

--- a/src/frontend/src/CustomNodes/GenericNode/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/index.tsx
@@ -1,5 +1,5 @@
 import { usePostValidateComponentCode } from "@/controllers/API/queries/nodes/use-post-validate-component-code";
-import { useEffect, useMemo, useState } from "react";
+import { memo, useEffect, useMemo, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { NodeToolbar, useUpdateNodeInternals } from "reactflow";
 import IconComponent, {
@@ -32,7 +32,7 @@ import NodeOutputField from "./components/NodeOutputfield";
 import NodeStatus from "./components/NodeStatus";
 import { NodeIcon } from "./components/nodeIcon";
 
-export default function GenericNode({
+const GenericNode = ({
   data,
   selected,
 }: {
@@ -40,7 +40,7 @@ export default function GenericNode({
   selected: boolean;
   xPos?: number;
   yPos?: number;
-}): JSX.Element {
+}): JSX.Element => {
   const types = useTypesStore((state) => state.types);
   const templates = useTypesStore((state) => state.templates);
   const deleteNode = useFlowStore((state) => state.deleteNode);
@@ -420,4 +420,6 @@ export default function GenericNode({
       </div>
     </>
   );
-}
+};
+
+export default memo(GenericNode);

--- a/src/frontend/src/CustomNodes/NoteNode/index.tsx
+++ b/src/frontend/src/CustomNodes/NoteNode/index.tsx
@@ -7,7 +7,7 @@ import {
 } from "@/constants/constants";
 import { noteDataType } from "@/types/flow";
 import { cn } from "@/utils/utils";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { NodeResizer, NodeToolbar } from "reactflow";
 import IconComponent from "../../components/genericIconComponent";
 import NodeDescription from "../GenericNode/components/NodeDescription";
@@ -107,4 +107,4 @@ function NoteNode({
   );
 }
 
-export default NoteNode;
+export default memo(NoteNode);


### PR DESCRIPTION
💡 What: Wrapped ReactFlow custom node components (`GenericNode` and `NoteNode`) in `React.memo()`. Also created `.jules/bolt.md` to document the learning.
🎯 Why: ReactFlow custom nodes re-render unnecessarily on canvas interactions (like panning and zooming) if they are not correctly memoized, which can lead to performance bottlenecks. 
📊 Impact: Considerably reduces component re-renders when users interact with the UI, making the application feel faster.
🔬 Measurement: Can be verified by measuring rendering times / re-renders using the React DevTools Profiler while dragging or interacting with nodes in the canvas.

---
*PR created automatically by Jules for task [13777056294948245378](https://jules.google.com/task/13777056294948245378) started by @ardy644*