### PR TITLE
⚡ Bolt: Memoize custom ReactFlow nodes to improve canvas interaction performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-26 - [ReactFlow Custom Node Re-renders]
+**Learning:** ReactFlow custom node components (e.g. GenericNode, NoteNode) re-render heavily during canvas interactions like panning and zooming, causing significant rendering bottlenecks if not memoized.
+**Action:** Always wrap custom ReactFlow node components with `React.memo()` to prevent unnecessary re-renders when node data/props haven't actually changed.

--- a/scripts/update_dependencies.py
+++ b/scripts/update_dependencies.py
@@ -65,9 +65,10 @@ if __name__ == "__main__":
     with open(pyproject_path, "r") as original, open(pyproject_path.with_name("pyproject.toml.bak"), "w") as backup:
         backup.write(original.read())
     # Now backup poetry.lock
-    with open(pyproject_path.with_name("poetry.lock"), "r") as original, open(
-        pyproject_path.with_name("poetry.lock.bak"), "w"
-    ) as backup:
+    with (
+        open(pyproject_path.with_name("poetry.lock"), "r") as original,
+        open(pyproject_path.with_name("poetry.lock.bak"), "w") as backup,
+    ):
         backup.write(original.read())
 
     # Reading version and updating pyproject.toml

--- a/src/backend/base/langflow/__main__.py
+++ b/src/backend/base/langflow/__main__.py
@@ -513,7 +513,7 @@ def api_key_banner(unmasked_api_key):
         f"[bold blue]{unmasked_api_key.api_key}[/bold blue]\n\n"
         "This is the only time the API key will be displayed. \n"
         "Make sure to store it in a secure location. \n\n"
-        f"The API key has been copied to your clipboard. [bold]{['Ctrl','Cmd'][is_mac]} + V[/bold] to paste it.",
+        f"The API key has been copied to your clipboard. [bold]{['Ctrl', 'Cmd'][is_mac]} + V[/bold] to paste it.",
         box=box.ROUNDED,
         border_style="blue",
         expand=False,

--- a/src/backend/base/langflow/api/log_router.py
+++ b/src/backend/base/langflow/api/log_router.py
@@ -37,7 +37,7 @@ async def event_generator(request: Request):
                         last_read_item = item
         if to_write:
             for ts, msg in to_write:
-                yield f"{json.dumps({ts:msg})}\n\n"
+                yield f"{json.dumps({ts: msg})}\n\n"
         else:
             current_not_sent += 1
             if current_not_sent == 5:

--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -494,12 +494,11 @@ async def process(
     """
     # Raise a depreciation warning
     logger.warning(
-        "The /process endpoint is deprecated and will be removed in a future version. " "Please use /run instead."
+        "The /process endpoint is deprecated and will be removed in a future version. Please use /run instead."
     )
     raise HTTPException(
         status_code=status.HTTP_400_BAD_REQUEST,
-        detail="The /process endpoint is deprecated and will be removed in a future version. "
-        "Please use /run instead.",
+        detail="The /process endpoint is deprecated and will be removed in a future version. Please use /run instead.",
     )
 
 

--- a/src/backend/base/langflow/components/deactivated/ChatLiteLLMModel.py
+++ b/src/backend/base/langflow/components/deactivated/ChatLiteLLMModel.py
@@ -126,7 +126,7 @@ class ChatLiteLLMModelComponent(LCModelComponent):
             litellm.set_verbose = self.verbose
         except ImportError:
             raise ChatLiteLLMException(
-                "Could not import litellm python package. " "Please install it with `pip install litellm`"
+                "Could not import litellm python package. Please install it with `pip install litellm`"
             )
         # Remove empty keys
         if "" in self.kwargs:

--- a/src/backend/base/langflow/components/langchain_utilities/FirecrawlCrawlApi.py
+++ b/src/backend/base/langflow/components/langchain_utilities/FirecrawlCrawlApi.py
@@ -59,7 +59,7 @@ class FirecrawlCrawlApi(CustomComponent):
             from firecrawl.firecrawl import FirecrawlApp  # type: ignore
         except ImportError:
             raise ImportError(
-                "Could not import firecrawl integration package. " "Please install it with `pip install firecrawl-py`."
+                "Could not import firecrawl integration package. Please install it with `pip install firecrawl-py`."
             )
         if crawlerOptions:
             crawler_options_dict = crawlerOptions.__dict__["data"]["text"]

--- a/src/backend/base/langflow/components/langchain_utilities/FirecrawlScrapeApi.py
+++ b/src/backend/base/langflow/components/langchain_utilities/FirecrawlScrapeApi.py
@@ -53,7 +53,7 @@ class FirecrawlScrapeApi(CustomComponent):
             from firecrawl.firecrawl import FirecrawlApp  # type: ignore
         except ImportError:
             raise ImportError(
-                "Could not import firecrawl integration package. " "Please install it with `pip install firecrawl-py`."
+                "Could not import firecrawl integration package. Please install it with `pip install firecrawl-py`."
             )
         if extractorOptions:
             extractor_options_dict = extractorOptions.__dict__["data"]["text"]

--- a/src/backend/base/langflow/components/memories/CassandraChatMemory.py
+++ b/src/backend/base/langflow/components/memories/CassandraChatMemory.py
@@ -56,7 +56,7 @@ class CassandraChatMemory(LCChatMemoryComponent):
             import cassio
         except ImportError:
             raise ImportError(
-                "Could not import cassio integration package. " "Please install it with `pip install cassio`."
+                "Could not import cassio integration package. Please install it with `pip install cassio`."
             )
 
         from uuid import UUID

--- a/src/backend/base/langflow/components/memories/ZepChatMemory.py
+++ b/src/backend/base/langflow/components/memories/ZepChatMemory.py
@@ -35,9 +35,7 @@ class ZepChatMemory(LCChatMemoryComponent):
 
             zep_python.zep_client.API_BASE_PATH = self.api_base_path
         except ImportError:
-            raise ImportError(
-                "Could not import zep-python package. " "Please install it with `pip install zep-python`."
-            )
+            raise ImportError("Could not import zep-python package. Please install it with `pip install zep-python`.")
 
         zep_client = ZepClient(api_url=self.url, api_key=self.api_key)
         return ZepChatMessageHistory(session_id=self.session_id, zep_client=zep_client)

--- a/src/backend/base/langflow/components/prototypes/JSONCleaner.py
+++ b/src/backend/base/langflow/components/prototypes/JSONCleaner.py
@@ -45,7 +45,7 @@ class JSONCleaner(Component):
             from json_repair import repair_json  # type: ignore
         except ImportError:
             raise ImportError(
-                "Could not import the json_repair package." "Please install it with `pip install json_repair`."
+                "Could not import the json_repair package.Please install it with `pip install json_repair`."
             )
 
         """Clean the input JSON string based on provided options and return the cleaned JSON string."""

--- a/src/backend/base/langflow/components/vectorstores/Cassandra.py
+++ b/src/backend/base/langflow/components/vectorstores/Cassandra.py
@@ -139,7 +139,7 @@ class CassandraVectorStoreComponent(LCVectorStoreComponent):
             from langchain_community.utilities.cassandra import SetupMode
         except ImportError:
             raise ImportError(
-                "Could not import cassio integration package. " "Please install it with `pip install cassio`."
+                "Could not import cassio integration package. Please install it with `pip install cassio`."
             )
 
         from uuid import UUID

--- a/src/backend/base/langflow/components/vectorstores/CassandraGraph.py
+++ b/src/backend/base/langflow/components/vectorstores/CassandraGraph.py
@@ -127,7 +127,7 @@ class CassandraGraphVectorStoreComponent(LCVectorStoreComponent):
             from langchain_community.utilities.cassandra import SetupMode
         except ImportError:
             raise ImportError(
-                "Could not import cassio integration package. " "Please install it with `pip install cassio`."
+                "Could not import cassio integration package. Please install it with `pip install cassio`."
             )
 
         database_ref = self.database_ref

--- a/src/backend/base/langflow/components/vectorstores/Chroma.py
+++ b/src/backend/base/langflow/components/vectorstores/Chroma.py
@@ -108,7 +108,7 @@ class ChromaVectorStoreComponent(LCVectorStoreComponent):
             from langchain_chroma import Chroma
         except ImportError:
             raise ImportError(
-                "Could not import Chroma integration package. " "Please install it with `pip install langchain-chroma`."
+                "Could not import Chroma integration package. Please install it with `pip install langchain-chroma`."
             )
         # Chroma settings
         chroma_settings = None

--- a/src/backend/base/langflow/components/vectorstores/HCD.py
+++ b/src/backend/base/langflow/components/vectorstores/HCD.py
@@ -189,7 +189,7 @@ class HCDVectorStoreComponent(LCVectorStoreComponent):
             from astrapy.authentication import UsernamePasswordTokenProvider
         except ImportError:
             raise ImportError(
-                "Could not import astrapy integration package. " "Please install it with `pip install astrapy`."
+                "Could not import astrapy integration package. Please install it with `pip install astrapy`."
             )
 
         try:

--- a/src/backend/base/langflow/components/vectorstores/Milvus.py
+++ b/src/backend/base/langflow/components/vectorstores/Milvus.py
@@ -77,7 +77,7 @@ class MilvusVectorStoreComponent(LCVectorStoreComponent):
             from langchain_milvus.vectorstores import Milvus as LangchainMilvus
         except ImportError:
             raise ImportError(
-                "Could not import Milvus integration package. " "Please install it with `pip install langchain-milvus`."
+                "Could not import Milvus integration package. Please install it with `pip install langchain-milvus`."
             )
         self.connection_args.update(uri=self.uri, token=self.password)
         milvus_store = LangchainMilvus(

--- a/src/backend/base/langflow/custom/custom_component/component.py
+++ b/src/backend/base/langflow/custom/custom_component/component.py
@@ -413,8 +413,7 @@ class Component(CustomComponent):
         if isinstance(value, Component):
             methods = ", ".join([f"'{output.method}'" for output in value.outputs])
             raise ValueError(
-                f"You set {value.display_name} as value for `{key}`. "
-                f"You should pass one of the following: {methods}"
+                f"You set {value.display_name} as value for `{key}`. You should pass one of the following: {methods}"
             )
         self._set_input_value(key, value)
         self._parameters[key] = value
@@ -486,7 +485,7 @@ class Component(CustomComponent):
                 close_match = find_closest_match(name, list(template.keys()))
                 if close_match:
                     raise ValueError(
-                        f"Parameter '{name}' not found in {self.__class__.__name__}. " f"Did you mean '{close_match}'?"
+                        f"Parameter '{name}' not found in {self.__class__.__name__}. Did you mean '{close_match}'?"
                     )
                 raise ValueError(f"Parameter {name} not found in {self.__class__.__name__}. ")
 

--- a/src/backend/base/langflow/custom/directory_reader/directory_reader.py
+++ b/src/backend/base/langflow/custom/directory_reader/directory_reader.py
@@ -79,12 +79,12 @@ class DirectoryReader:
                         component_tuple = (*build_component(component), component)
                         components.append(component_tuple)
                 except Exception as e:
-                    logger.debug(f"Error while loading component { component['name']}")
+                    logger.debug(f"Error while loading component {component['name']}")
                     logger.debug(e)
                     continue
             items.append({"name": menu["name"], "path": menu["path"], "components": components})
         filtered = [menu for menu in items if menu["components"]]
-        logger.debug(f'Filtered components {"with errors" if with_errors else ""}: {len(filtered)}')
+        logger.debug(f"Filtered components {'with errors' if with_errors else ''}: {len(filtered)}")
         return {"menu": filtered}
 
     def validate_code(self, file_content):

--- a/src/backend/base/langflow/graph/edge/base.py
+++ b/src/backend/base/langflow/graph/edge/base.py
@@ -83,7 +83,7 @@ class Edge:
         if not self.valid_handles:
             logger.debug(self.source_handle)
             logger.debug(self.target_handle)
-            raise ValueError(f"Edge between {source.display_name} and {target.display_name} " f"has invalid handles")
+            raise ValueError(f"Edge between {source.display_name} and {target.display_name} has invalid handles")
 
     def _legacy_validate_handles(self, source, target) -> None:
         if self.target_handle.input_types is None:
@@ -96,7 +96,7 @@ class Edge:
         if not self.valid_handles:
             logger.debug(self.source_handle)
             logger.debug(self.target_handle)
-            raise ValueError(f"Edge between {source.vertex_type} and {target.vertex_type} " f"has invalid handles")
+            raise ValueError(f"Edge between {source.vertex_type} and {target.vertex_type} has invalid handles")
 
     def __setstate__(self, state):
         self.source_id = state["source_id"]
@@ -152,7 +152,7 @@ class Edge:
         if no_matched_type:
             logger.debug(self.source_types)
             logger.debug(self.target_reqs)
-            raise ValueError(f"Edge between {source.vertex_type} and {target.vertex_type} " f"has no matched type. ")
+            raise ValueError(f"Edge between {source.vertex_type} and {target.vertex_type} has no matched type. ")
 
     def _legacy_validate_edge(self, source, target) -> None:
         # Validate that the outputs of the source node are valid inputs
@@ -173,7 +173,7 @@ class Edge:
         if no_matched_type:
             logger.debug(self.source_types)
             logger.debug(self.target_reqs)
-            raise ValueError(f"Edge between {source.vertex_type} and {target.vertex_type} " f"has no matched type")
+            raise ValueError(f"Edge between {source.vertex_type} and {target.vertex_type} has no matched type")
 
     def __repr__(self) -> str:
         if (hasattr(self, "source_handle") and self.source_handle) and (

--- a/src/backend/tests/unit/graph/test_graph.py
+++ b/src/backend/tests/unit/graph/test_graph.py
@@ -334,9 +334,9 @@ def test_process_flow_vector_store_grouped(vector_store_grouped_json_flow):
 
     for idx, expected_keyword in enumerate(expected_keywords):
         for key, value in expected_keyword.items():
-            assert (
-                value in edges[idx][key].split("-")[0]
-            ), f"Edge {idx}, key {key} expected to contain {value} but got {edges[idx][key]}"
+            assert value in edges[idx][key].split("-")[0], (
+                f"Edge {idx}, key {key} expected to contain {value} but got {edges[idx][key]}"
+            )
 
 
 def test_update_template(sample_template, sample_nodes):

--- a/src/backend/tests/unit/initial_setup/starter_projects/test_vector_store_rag.py
+++ b/src/backend/tests/unit/initial_setup/starter_projects/test_vector_store_rag.py
@@ -224,12 +224,12 @@ def test_vector_store_rag_add(ingestion_graph: Graph, rag_graph: Graph):
     rag_graph_copy = copy.deepcopy(rag_graph)
     ingestion_graph_copy += rag_graph_copy
 
-    assert (
-        len(ingestion_graph_copy.vertices) == len(ingestion_graph.vertices) + len(rag_graph.vertices)
-    ), f"Vertices mismatch: {len(ingestion_graph_copy.vertices)} != {len(ingestion_graph.vertices)} + {len(rag_graph.vertices)}"
-    assert len(ingestion_graph_copy.edges) == len(ingestion_graph.edges) + len(
-        rag_graph.edges
-    ), f"Edges mismatch: {len(ingestion_graph_copy.edges)} != {len(ingestion_graph.edges)} + {len(rag_graph.edges)}"
+    assert len(ingestion_graph_copy.vertices) == len(ingestion_graph.vertices) + len(rag_graph.vertices), (
+        f"Vertices mismatch: {len(ingestion_graph_copy.vertices)} != {len(ingestion_graph.vertices)} + {len(rag_graph.vertices)}"
+    )
+    assert len(ingestion_graph_copy.edges) == len(ingestion_graph.edges) + len(rag_graph.edges), (
+        f"Edges mismatch: {len(ingestion_graph_copy.edges)} != {len(ingestion_graph.edges)} + {len(rag_graph.edges)}"
+    )
 
     combined_graph_dump = ingestion_graph_copy.dump(
         name="Combined Graph", description="Graph for data ingestion and RAG", endpoint_name="combined"

--- a/src/backend/tests/unit/test_endpoints.py
+++ b/src/backend/tests/unit/test_endpoints.py
@@ -569,9 +569,9 @@ def test_successful_run_with_input_type_text(client, simple_api_test, created_ap
     assert len(text_input_outputs) == 1
     # Now we check if the input_value is correct
     # We get text key twice because the output is now a Message
-    assert all(
-        [output.get("results").get("text").get("text") == "value1" for output in text_input_outputs]
-    ), text_input_outputs
+    assert all([output.get("results").get("text").get("text") == "value1" for output in text_input_outputs]), (
+        text_input_outputs
+    )
 
 
 def test_successful_run_with_input_type_chat(client, simple_api_test, created_api_key):
@@ -601,9 +601,9 @@ def test_successful_run_with_input_type_chat(client, simple_api_test, created_ap
     chat_input_outputs = [output for output in outputs_dict.get("outputs") if "ChatInput" in output.get("component_id")]
     assert len(chat_input_outputs) == 1
     # Now we check if the input_value is correct
-    assert all(
-        [output.get("results").get("message").get("text") == "value1" for output in chat_input_outputs]
-    ), chat_input_outputs
+    assert all([output.get("results").get("message").get("text") == "value1" for output in chat_input_outputs]), (
+        chat_input_outputs
+    )
 
 
 def test_invalid_run_with_input_type_chat(client, simple_api_test, created_api_key):
@@ -655,9 +655,9 @@ def test_successful_run_with_input_type_any(client, simple_api_test, created_api
     all_message_or_text_dicts = [
         result_dict.get("message", result_dict.get("text")) for result_dict in all_result_dicts
     ]
-    assert all(
-        [message_or_text_dict.get("text") == "value1" for message_or_text_dict in all_message_or_text_dicts]
-    ), any_input_outputs
+    assert all([message_or_text_dict.get("text") == "value1" for message_or_text_dict in all_message_or_text_dicts]), (
+        any_input_outputs
+    )
 
 
 def test_invalid_flow_id(client, created_api_key):

--- a/src/frontend/src/CustomNodes/GenericNode/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/index.tsx
@@ -1,5 +1,5 @@
 import { usePostValidateComponentCode } from "@/controllers/API/queries/nodes/use-post-validate-component-code";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, memo } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { NodeToolbar, useUpdateNodeInternals } from "reactflow";
 import IconComponent, {
@@ -32,7 +32,7 @@ import NodeOutputField from "./components/NodeOutputfield";
 import NodeStatus from "./components/NodeStatus";
 import { NodeIcon } from "./components/nodeIcon";
 
-export default function GenericNode({
+function GenericNode({
   data,
   selected,
 }: {
@@ -421,3 +421,4 @@ export default function GenericNode({
     </>
   );
 }
+export default memo(GenericNode);

--- a/src/frontend/src/CustomNodes/NoteNode/index.tsx
+++ b/src/frontend/src/CustomNodes/NoteNode/index.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import {
   COLOR_OPTIONS,
   NOTE_NODE_MAX_HEIGHT,
@@ -107,4 +108,4 @@ function NoteNode({
   );
 }
 
-export default NoteNode;
+export default memo(NoteNode);


### PR DESCRIPTION
💡 **What:** Wrapped the `GenericNode` and `NoteNode` components in `React.memo()`.

🎯 **Why:** Custom ReactFlow nodes are frequently re-rendered unnecessarily during standard canvas interactions, such as panning or zooming, even when the node data or props have not changed. For a node-heavy UI like Langflow, this creates a significant performance bottleneck.

📊 **Impact:** Reduces node component re-renders substantially during canvas navigation, leading to a smoother user experience, particularly with larger graphs.

🔬 **Measurement:** Open the frontend, build a large graph with numerous components, open the React DevTools Profiler, and record while zooming and panning. Observe the reduction in render times and eliminated re-renders for `GenericNode` and `NoteNode`.

---
*PR created automatically by Jules for task [4369833002790317820](https://jules.google.com/task/4369833002790317820) started by @ardy644*