### PR TITLE
⚡ Bolt: Add React.memo() to Custom Nodes

### DIFF
--- a/src/frontend/src/CustomNodes/GenericNode/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/index.tsx
@@ -422,4 +422,6 @@ function GenericNode({
   );
 }
 
+// ⚡ Bolt: Wrapped GenericNode in React.memo to prevent unnecessary re-renders when
+// the React Flow canvas changes (e.g., during panning or zooming). This reduces expensive DOM recalculations.
 export default memo(GenericNode);

--- a/src/frontend/src/CustomNodes/GenericNode/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/index.tsx
@@ -1,5 +1,5 @@
 import { usePostValidateComponentCode } from "@/controllers/API/queries/nodes/use-post-validate-component-code";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, memo } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { NodeToolbar, useUpdateNodeInternals } from "reactflow";
 import IconComponent, {
@@ -32,7 +32,7 @@ import NodeOutputField from "./components/NodeOutputfield";
 import NodeStatus from "./components/NodeStatus";
 import { NodeIcon } from "./components/nodeIcon";
 
-export default function GenericNode({
+function GenericNode({
   data,
   selected,
 }: {
@@ -421,3 +421,5 @@ export default function GenericNode({
     </>
   );
 }
+
+export default memo(GenericNode);

--- a/src/frontend/src/CustomNodes/GenericNode/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/index.tsx
@@ -1,5 +1,5 @@
 import { usePostValidateComponentCode } from "@/controllers/API/queries/nodes/use-post-validate-component-code";
-import { useEffect, useMemo, useState, memo } from "react";
+import { memo, useEffect, useMemo, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { NodeToolbar, useUpdateNodeInternals } from "reactflow";
 import IconComponent, {

--- a/src/frontend/src/CustomNodes/NoteNode/index.tsx
+++ b/src/frontend/src/CustomNodes/NoteNode/index.tsx
@@ -7,7 +7,7 @@ import {
 } from "@/constants/constants";
 import { noteDataType } from "@/types/flow";
 import { cn } from "@/utils/utils";
-import { useEffect, useMemo, useRef, useState, memo } from "react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { NodeResizer, NodeToolbar } from "reactflow";
 import IconComponent from "../../components/genericIconComponent";
 import NodeDescription from "../GenericNode/components/NodeDescription";

--- a/src/frontend/src/CustomNodes/NoteNode/index.tsx
+++ b/src/frontend/src/CustomNodes/NoteNode/index.tsx
@@ -107,4 +107,6 @@ function NoteNode({
   );
 }
 
+// ⚡ Bolt: Wrapped NoteNode in React.memo to prevent unnecessary re-renders when
+// the React Flow canvas changes (e.g., during panning or zooming). This reduces expensive DOM recalculations.
 export default memo(NoteNode);

--- a/src/frontend/src/CustomNodes/NoteNode/index.tsx
+++ b/src/frontend/src/CustomNodes/NoteNode/index.tsx
@@ -7,7 +7,7 @@ import {
 } from "@/constants/constants";
 import { noteDataType } from "@/types/flow";
 import { cn } from "@/utils/utils";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, memo } from "react";
 import { NodeResizer, NodeToolbar } from "reactflow";
 import IconComponent from "../../components/genericIconComponent";
 import NodeDescription from "../GenericNode/components/NodeDescription";
@@ -107,4 +107,4 @@ function NoteNode({
   );
 }
 
-export default NoteNode;
+export default memo(NoteNode);


### PR DESCRIPTION
💡 What: Wrapped ReactFlow custom node components (`GenericNode` and `NoteNode`) with `React.memo()`.
🎯 Why: In React Flow, whenever the global graph state changes (e.g., panning, zooming, dragging other nodes), all nodes can re-render if not memoized. This causes severe UI lag and expensive DOM recalculations.
📊 Impact: Eliminates unnecessary re-renders of custom nodes when unrelated canvas updates occur, resulting in a noticeably smoother editing experience on large graphs.
🔬 Measurement: Use React DevTools Profiler while panning/zooming the canvas to observe that `GenericNode` and `NoteNode` instances skip rendering when their props haven't changed.

---
*PR created automatically by Jules for task [14988181966848754468](https://jules.google.com/task/14988181966848754468) started by @ardy644*