### PR TITLE
⚡ Bolt: Memoize custom nodes to prevent unnecessary re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-29 - [ReactFlow Custom Nodes Re-render Bottleneck]
+**Learning:** ReactFlow custom nodes render frequently during canvas interactions (panning, zooming), creating a performance bottleneck if components like `GenericNode` and `NoteNode` are not memoized, causing unnecessary re-renders across the large canvas.
+**Action:** Always wrap custom node components in ReactFlow with `React.memo()` to ensure a shallow prop comparison prevents these unnecessary rendering bottlenecks.

--- a/src/frontend/src/CustomNodes/GenericNode/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/index.tsx
@@ -1,5 +1,5 @@
 import { usePostValidateComponentCode } from "@/controllers/API/queries/nodes/use-post-validate-component-code";
-import { useEffect, useMemo, useState } from "react";
+import { memo, useEffect, useMemo, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { NodeToolbar, useUpdateNodeInternals } from "reactflow";
 import IconComponent, {
@@ -32,7 +32,7 @@ import NodeOutputField from "./components/NodeOutputfield";
 import NodeStatus from "./components/NodeStatus";
 import { NodeIcon } from "./components/nodeIcon";
 
-export default function GenericNode({
+function GenericNode({
   data,
   selected,
 }: {
@@ -421,3 +421,5 @@ export default function GenericNode({
     </>
   );
 }
+
+export default memo(GenericNode);

--- a/src/frontend/src/CustomNodes/NoteNode/index.tsx
+++ b/src/frontend/src/CustomNodes/NoteNode/index.tsx
@@ -7,7 +7,7 @@ import {
 } from "@/constants/constants";
 import { noteDataType } from "@/types/flow";
 import { cn } from "@/utils/utils";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { NodeResizer, NodeToolbar } from "reactflow";
 import IconComponent from "../../components/genericIconComponent";
 import NodeDescription from "../GenericNode/components/NodeDescription";
@@ -107,4 +107,4 @@ function NoteNode({
   );
 }
 
-export default NoteNode;
+export default memo(NoteNode);


### PR DESCRIPTION
💡 What: Wrapped `GenericNode` and `NoteNode` ReactFlow custom components in `React.memo()`.

🎯 Why: Custom nodes in ReactFlow are frequently re-rendered during canvas interactions (like panning or zooming) or when unrelated node state changes occur. This causes a significant performance bottleneck in large graphs. `React.memo()` performs a shallow comparison of props (which works perfectly with ReactFlow's immutable state updates) and prevents these unnecessary re-renders.

📊 Impact: Reduces unnecessary re-renders of complex node structures by a significant margin during canvas navigation, leading to a much smoother user experience on large flows.

🔬 Measurement: Can be verified by using the React DevTools Profiler while panning/zooming around a populated flow. The nodes will no longer appear in the list of re-rendered components unless their explicit data or selected state changes.

---
*PR created automatically by Jules for task [2934665016090330078](https://jules.google.com/task/2934665016090330078) started by @ardy644*