### PR TITLE
⚡ Bolt: Add React.memo to Custom Nodes to prevent unnecessary re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## $(date +%Y-%m-%d) - React Flow Custom Nodes Rendering Optimization
+**Learning:** React Flow custom nodes are highly susceptible to unnecessary re-renders during canvas interactions (like panning and zooming) if they are not properly memoized. The custom nodes re-evaluate on every flow state change, which can bottleneck performance.
+**Action:** Always wrap custom node components (`GenericNode`, `NoteNode`, etc.) exported to React Flow with `React.memo()` to utilize shallow prop comparison and prevent these excessive re-renders.

--- a/src/frontend/src/CustomNodes/GenericNode/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/index.tsx
@@ -1,5 +1,5 @@
 import { usePostValidateComponentCode } from "@/controllers/API/queries/nodes/use-post-validate-component-code";
-import { useEffect, useMemo, useState } from "react";
+import { memo, useEffect, useMemo, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { NodeToolbar, useUpdateNodeInternals } from "reactflow";
 import IconComponent, {
@@ -32,7 +32,7 @@ import NodeOutputField from "./components/NodeOutputfield";
 import NodeStatus from "./components/NodeStatus";
 import { NodeIcon } from "./components/nodeIcon";
 
-export default function GenericNode({
+function GenericNodeComponent({
   data,
   selected,
 }: {
@@ -421,3 +421,5 @@ export default function GenericNode({
     </>
   );
 }
+
+export default memo(GenericNodeComponent);

--- a/src/frontend/src/CustomNodes/NoteNode/index.tsx
+++ b/src/frontend/src/CustomNodes/NoteNode/index.tsx
@@ -7,13 +7,13 @@ import {
 } from "@/constants/constants";
 import { noteDataType } from "@/types/flow";
 import { cn } from "@/utils/utils";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { NodeResizer, NodeToolbar } from "reactflow";
 import IconComponent from "../../components/genericIconComponent";
 import NodeDescription from "../GenericNode/components/NodeDescription";
 import NodeName from "../GenericNode/components/NodeName";
 import NoteToolbarComponent from "./NoteToolbarComponent";
-function NoteNode({
+function NoteNodeComponent({
   data,
   selected,
 }: {
@@ -107,4 +107,4 @@ function NoteNode({
   );
 }
 
-export default NoteNode;
+export default memo(NoteNodeComponent);


### PR DESCRIPTION
💡 What: Wrapped `GenericNode` and `NoteNode` custom components with `React.memo()` in `src/frontend/src/CustomNodes/`.

🎯 Why: Custom nodes in ReactFlow re-render excessively on any canvas state change (e.g., panning, zooming) unless they are memoized. This caused significant performance bottlenecks on flow charts with multiple nodes.

📊 Impact: Massively reduces re-renders for custom node components during interactions. For example, panning over a flow with 10 nodes will no longer trigger re-renders for all 10 nodes for every mouse move event.

🔬 Measurement: Verify by loading a flow with multiple nodes, enabling the React DevTools Profiler (with "Record why each component rendered while profiling" turned on), and observing the drastically reduced render counts when panning the canvas compared to before the change.

---
*PR created automatically by Jules for task [13926784037129986142](https://jules.google.com/task/13926784037129986142) started by @ardy644*