### PR TITLE
⚡ Bolt: Memoize CustomNodes to prevent re-renders

### DIFF
--- a/src/frontend/src/CustomNodes/GenericNode/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/index.tsx
@@ -32,7 +32,9 @@ import NodeOutputField from "./components/NodeOutputfield";
 import NodeStatus from "./components/NodeStatus";
 import { NodeIcon } from "./components/nodeIcon";
 
-export default function GenericNode({
+import React from "react";
+
+function GenericNodeComponent({
   data,
   selected,
 }: {
@@ -421,3 +423,6 @@ export default function GenericNode({
     </>
   );
 }
+
+// Wrap the component in React.memo to prevent unnecessary re-renders when interacting with the ReactFlow canvas (e.g., panning, zooming).
+export default React.memo(GenericNodeComponent);

--- a/src/frontend/src/CustomNodes/NoteNode/index.tsx
+++ b/src/frontend/src/CustomNodes/NoteNode/index.tsx
@@ -7,7 +7,7 @@ import {
 } from "@/constants/constants";
 import { noteDataType } from "@/types/flow";
 import { cn } from "@/utils/utils";
-import { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { NodeResizer, NodeToolbar } from "reactflow";
 import IconComponent from "../../components/genericIconComponent";
 import NodeDescription from "../GenericNode/components/NodeDescription";
@@ -107,4 +107,5 @@ function NoteNode({
   );
 }
 
-export default NoteNode;
+// Wrap the component in React.memo to prevent unnecessary re-renders when interacting with the ReactFlow canvas (e.g., panning, zooming).
+export default React.memo(NoteNode);


### PR DESCRIPTION
💡 What: Wrapped `GenericNode` and `NoteNode` components in `React.memo()`. Added inline comments explaining the purpose of the optimization.
🎯 Why: ReactFlow's complex custom node components can cause severe performance degradation (unnecessary re-renders) during canvas interactions (panning, zooming, etc.) if not memoized, due to React doing a deep comparison on complex props.
📊 Impact: Reduces re-renders of node components significantly, leading to a much smoother canvas interaction experience, especially in flows with many nodes.
🔬 Measurement: Verify the improvement by rendering a large flow and monitoring React component renders using the React DevTools Profiler while panning and zooming the canvas. Node components should no longer re-render continuously.

---
*PR created automatically by Jules for task [8406895449148894238](https://jules.google.com/task/8406895449148894238) started by @ardy644*