### PR TITLE
⚡ Bolt: Memoize custom nodes to prevent unnecessary re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-07-07 - Memoizing ReactFlow Custom Nodes
+**Learning:** In this architecture, ReactFlow custom node components (like GenericNode and NoteNode) must be wrapped with `React.memo()`. Unmemoized custom nodes cause unnecessary and expensive re-renders across the canvas during interactions such as panning and zooming, leading to a rendering bottleneck and poor performance.
+**Action:** Always wrap custom node components in ReactFlow with `React.memo()` to ensure stable performance during canvas interactions.

--- a/src/frontend/src/CustomNodes/GenericNode/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/index.tsx
@@ -1,5 +1,5 @@
 import { usePostValidateComponentCode } from "@/controllers/API/queries/nodes/use-post-validate-component-code";
-import { useEffect, useMemo, useState } from "react";
+import { memo, useEffect, useMemo, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { NodeToolbar, useUpdateNodeInternals } from "reactflow";
 import IconComponent, {
@@ -32,7 +32,7 @@ import NodeOutputField from "./components/NodeOutputfield";
 import NodeStatus from "./components/NodeStatus";
 import { NodeIcon } from "./components/nodeIcon";
 
-export default function GenericNode({
+function GenericNode({
   data,
   selected,
 }: {
@@ -421,3 +421,5 @@ export default function GenericNode({
     </>
   );
 }
+
+export default memo(GenericNode);

--- a/src/frontend/src/CustomNodes/NoteNode/index.tsx
+++ b/src/frontend/src/CustomNodes/NoteNode/index.tsx
@@ -7,7 +7,7 @@ import {
 } from "@/constants/constants";
 import { noteDataType } from "@/types/flow";
 import { cn } from "@/utils/utils";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { NodeResizer, NodeToolbar } from "reactflow";
 import IconComponent from "../../components/genericIconComponent";
 import NodeDescription from "../GenericNode/components/NodeDescription";
@@ -107,4 +107,4 @@ function NoteNode({
   );
 }
 
-export default NoteNode;
+export default memo(NoteNode);


### PR DESCRIPTION
💡 **What:**
Wrapped the ReactFlow custom node components (`GenericNode` and `NoteNode`) in `React.memo()`.

🎯 **Why:**
Without memoization, ReactFlow re-renders these complex custom nodes frequently during canvas interactions like panning or zooming, which can lead to significant rendering bottlenecks and lag on large canvases.

📊 **Impact:**
Reduces unnecessary re-renders of node components during global canvas state changes, significantly improving visual performance and responsiveness during drag/pan/zoom actions.

🔬 **Measurement:**
Open a large flow graph in the canvas. Use React Developer Tools with the "Highlight updates when components render" option enabled. Try panning and zooming the canvas. Before this change, the nodes would highlight frequently; after this change, they will only highlight when their specific properties or internal states change.

---
*PR created automatically by Jules for task [12397100627155959582](https://jules.google.com/task/12397100627155959582) started by @ardy644*