### PR TITLE
⚡ Bolt: Memoize GenericNode and NoteNode components

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-07-08 - [ReactFlow Re-renders Bottleneck]
+**Learning:** Langflow's custom nodes (like GenericNode and NoteNode) were re-rendering heavily on every canvas interaction (panning, zooming) because they were not memoized. ReactFlow explicitly passes state changes to all nodes, meaning un-memoized custom nodes cause extreme overhead when rendering complex UIs.
+**Action:** Always wrap custom node components in ReactFlow with `React.memo()` to ensure shallow prop comparison.

--- a/src/frontend/src/CustomNodes/GenericNode/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/index.tsx
@@ -1,5 +1,5 @@
 import { usePostValidateComponentCode } from "@/controllers/API/queries/nodes/use-post-validate-component-code";
-import { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { NodeToolbar, useUpdateNodeInternals } from "reactflow";
 import IconComponent, {
@@ -32,7 +32,7 @@ import NodeOutputField from "./components/NodeOutputfield";
 import NodeStatus from "./components/NodeStatus";
 import { NodeIcon } from "./components/nodeIcon";
 
-export default function GenericNode({
+function GenericNode({
   data,
   selected,
 }: {
@@ -421,3 +421,6 @@ export default function GenericNode({
     </>
   );
 }
+// ⚡ Bolt: Memoize component to prevent unnecessary re-renders during canvas interactions (e.g., panning, zooming, selecting other nodes).
+// Impact: Reduces React rendering overhead significantly when the canvas contains many nodes.
+export default React.memo(GenericNode);

--- a/src/frontend/src/CustomNodes/NoteNode/index.tsx
+++ b/src/frontend/src/CustomNodes/NoteNode/index.tsx
@@ -7,7 +7,7 @@ import {
 } from "@/constants/constants";
 import { noteDataType } from "@/types/flow";
 import { cn } from "@/utils/utils";
-import { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { NodeResizer, NodeToolbar } from "reactflow";
 import IconComponent from "../../components/genericIconComponent";
 import NodeDescription from "../GenericNode/components/NodeDescription";
@@ -107,4 +107,6 @@ function NoteNode({
   );
 }
 
-export default NoteNode;
+// ⚡ Bolt: Memoize component to prevent unnecessary re-renders during canvas interactions (e.g., panning, zooming, selecting other nodes).
+// Impact: Reduces React rendering overhead significantly when the canvas contains many nodes.
+export default React.memo(NoteNode);


### PR DESCRIPTION
💡 **What:** Wrapped `GenericNode` and `NoteNode` custom components with `React.memo()`. Added inline performance comments as required.
🎯 **Why:** In React Flow, canvas interactions such as panning or zooming trigger global updates. Without `React.memo`, every custom node re-renders on these interactions, causing massive performance overhead when the canvas contains many nodes.
📊 **Impact:** Reduces React rendering overhead significantly. Unnecessary re-renders of nodes during viewport interactions are eliminated.
🔬 **Measurement:** Verify by placing multiple generic nodes or note nodes on the canvas, opening React DevTools Profiler, and observing that they no longer trigger render cycles when panning or zooming the canvas.

---
*PR created automatically by Jules for task [14665714656692915342](https://jules.google.com/task/14665714656692915342) started by @ardy644*