### PR TITLE
⚡ Bolt: Memoize NodeInputField and NodeOutputField to reduce re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,3 @@
-## 2024-07-08 - [ReactFlow Re-renders Bottleneck]
-**Learning:** Langflow's custom nodes (like GenericNode and NoteNode) were re-rendering heavily on every canvas interaction (panning, zooming) because they were not memoized. ReactFlow explicitly passes state changes to all nodes, meaning un-memoized custom nodes cause extreme overhead when rendering complex UIs.
-**Action:** Always wrap custom node components in ReactFlow with `React.memo()` to ensure shallow prop comparison.
+## 2024-07-25 - ReactFlow Node Bottlenecks
+**Learning:** ReactFlow custom nodes (`GenericNode`, `NoteNode`) were memoized, but their heavily utilized internal components like `NodeInputField` and `NodeOutputField` were not. When panning/zooming, these inner components still incurred React rendering overhead. Memoizing these inner children provides a significant optimization for nodes with many inputs/outputs.
+**Action:** When working with ReactFlow custom nodes, always investigate and apply `React.memo()` to heavily rendered child components (inputs, outputs, parameters), not just the parent node component wrapper.

--- a/src/frontend/src/CustomNodes/GenericNode/components/NodeInputField/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/NodeInputField/index.tsx
@@ -4,7 +4,7 @@ import {
   CustomParameterComponent,
   getCustomParameterTitle,
 } from "@/customization/components/custom-parameter";
-import { useEffect, useRef } from "react";
+import React, { useEffect, useRef } from "react";
 import { default as IconComponent } from "../../../../components/genericIconComponent";
 import ShadTooltip from "../../../../components/shadTooltipComponent";
 import { LANGFLOW_SUPPORTED_TYPES } from "../../../../constants/constants";
@@ -17,7 +17,9 @@ import useHandleOnNewValue from "../../../hooks/use-handle-new-value";
 import NodeInputInfo from "../NodeInputInfo";
 import HandleRenderComponent from "../handleRenderComponent";
 
-export default function NodeInputField({
+// ⚡ Bolt: Memoize component to prevent unnecessary re-renders during canvas interactions (e.g., panning, zooming).
+// Impact: Reduces React rendering overhead significantly when the canvas contains many nodes.
+function NodeInputField({
   id,
   data,
   tooltipTitle,
@@ -159,3 +161,5 @@ export default function NodeInputField({
     </div>
   );
 }
+
+export default React.memo(NodeInputField);

--- a/src/frontend/src/CustomNodes/GenericNode/components/NodeOutputfield/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/NodeOutputfield/index.tsx
@@ -1,5 +1,5 @@
 import { cloneDeep } from "lodash";
-import { useEffect, useRef } from "react";
+import React, { useEffect, useRef } from "react";
 import { useUpdateNodeInternals } from "reactflow";
 import { default as IconComponent } from "../../../../components/genericIconComponent";
 import ShadTooltip from "../../../../components/shadTooltipComponent";
@@ -22,7 +22,9 @@ import OutputComponent from "../OutputComponent";
 import HandleRenderComponent from "../handleRenderComponent";
 import OutputModal from "../outputModal";
 
-export default function NodeOutputField({
+// ⚡ Bolt: Memoize component to prevent unnecessary re-renders during canvas interactions (e.g., panning, zooming).
+// Impact: Reduces React rendering overhead significantly when the canvas contains many nodes.
+function NodeOutputField({
   selected,
   data,
   title,
@@ -216,3 +218,5 @@ export default function NodeOutputField({
     </div>
   );
 }
+
+export default React.memo(NodeOutputField);


### PR DESCRIPTION
💡 What: Wrapped `NodeInputField` and `NodeOutputField` components in `src/frontend/src/CustomNodes/GenericNode/components/` with `React.memo()`.

🎯 Why: In ReactFlow, canvas interactions like panning and zooming can cause unnecessary re-renders of custom node child components. Memoizing these heavily used internal field components prevents React from needlessly re-rendering them when their props have not changed.

📊 Impact: Reduces React rendering overhead significantly, especially on complex canvases containing many nodes with multiple input and output fields.

🔬 Measurement: Check the React DevTools Profiler while panning or zooming on a heavily populated canvas. The render durations for these field components should drop dramatically because they will bail out of updates.

---
*PR created automatically by Jules for task [6410747073210234960](https://jules.google.com/task/6410747073210234960) started by @ardy644*